### PR TITLE
Fix InfoBundle issue with CFBundleDisplayName.

### DIFF
--- a/TLDomainHooker.xm
+++ b/TLDomainHooker.xm
@@ -146,7 +146,7 @@ MSHook(NSString *, SPDisplayNameForExtendedDomain, int domain) {
 		NSArray *extendedDomains = SPGetExtendedDomains();
 
 		for (NSDictionary *dom in extendedDomains) {
-			if ([[dom objectForKey:@"SPDisplayIdentifier"] isEqualToString:SPDisplayIdentifierForDomain(domain)]) {
+			if ([[dom objectForKey:@"SPDisplayIdentifier"] isEqualToString:SPDisplayIdentifierForDomain(domain)] && [[dom objectForKey:@"SPCategory"] isEqualToString:category]) {
 				ret = [dom objectForKey:@"TLDisplayName"] ?: ret;
 			}
 		}


### PR DESCRIPTION
Suppose you had a search bundle that had two InfoBundles:
- John: SPCategory: Appleseed, SPDisplayIdentifier: com.bacon.bacon
- Mark: SPCategory: Orangeseed, SPDisplayIdentifier: com.bacon.bacon

With the original hook, SPDisplayNameForExtendedDomain would loop through all the InfoBundles and when the SPDisplayIdentifier matched it would return the TLDisplayName key regardless of the SPCategory key. This patch ensures that SPDisplayNameForExtendedDomain checks both the SPDisplayIdentifier and SPCategory.

Thanks.
